### PR TITLE
Header css 개선 및 로그인 상태에 따라 헤더 버튼 전환

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
-        "axios": "^1.6.7",
         "@monaco-editor/react": "^4.6.0",
+        "axios": "^1.6.7",
         "emotion": "^11.0.0",
         "monaco-themes": "^0.4.4",
         "react": "^18.2.0",
@@ -3024,7 +3024,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3212,7 +3211,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",

--- a/src/components/Carousel/SplashCarousel.tsx
+++ b/src/components/Carousel/SplashCarousel.tsx
@@ -27,7 +27,7 @@ const carouselData = [
 ];
 
 // TODO: 캐러셀 슬라이드 넘길 수 있는 커스텀 버튼 필요
-const SplashCarousel = () => {
+export const SplashCarousel = () => {
   return (
     <>
       <Carousel
@@ -82,5 +82,3 @@ const StyledCarousel = styled.div`
     max-width: 451px;
   }
 `;
-
-export default SplashCarousel;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,42 +1,67 @@
 import styled from "@emotion/styled";
+import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 
-const Header = () => {
+export const Header = () => {
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    setIsLoggedIn(token !== null);
+  }, []);
+
   return (
     <StyledHeader>
-      <h1>CodeCatcher</h1>
-      <button>로그인</button>
+      <h1>Codee</h1>
+      {!isLoggedIn ? (
+        <StyledLoginBtn>로그인</StyledLoginBtn>
+      ) : (
+        <StyledBtnGroup>
+          <button>로그아웃</button>
+          <button onClick={() => navigate("/my-page")}>마이페이지</button>
+        </StyledBtnGroup>
+      )}
     </StyledHeader>
   );
 };
 
 const StyledHeader = styled.header`
-  max-width: 1280px;
-  height: 100px;
-  margin: 0 auto;
+  width: 100%;
+  padding: 10px 30px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  position: sticky;
-  top: 0;
-  padding: 0 20px;
+  background-color: var(--background-color);
 
   & > h1 {
     font-size: 24px;
     font-weight: 600;
-    /* color: #ffffff; */
+    color: #ffffff;
   }
 
-  & > button {
-    padding: 0 26.5px;
-    /* border: none; */
-    background-color: #ffffff;
-    color: #222222;
+  & button {
     font-size: 16px;
     font-weight: 600;
-    line-height: 40px;
-    border-radius: 999px;
     cursor: pointer;
   }
 `;
 
-export default Header;
+const StyledLoginBtn = styled.button`
+  padding: 12px 26.5px;
+  background-color: #ffffff;
+  color: #222222;
+  border-radius: 999px;
+`;
+
+const StyledBtnGroup = styled.div`
+  & > button {
+    border: none;
+    background-color: transparent;
+    padding: 10px;
+  }
+
+  & > button:not(:first-child) {
+    margin-left: 20px;
+  }
+`;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,5 +3,7 @@ import { SelectLang } from "./codingTest/SelectLang";
 import { TestDescSection } from "./codingTest/TestDescSection";
 import { TestResultSection } from "./codingTest/TestResultSection";
 import { Modal } from "./common/Modal";
+import { Header } from "./common/Header";
+import { SplashCarousel } from "./Carousel/SplashCarousel";
 
 export { Header, SplashCarousel, CodeEditor, SelectLang, TestDescSection, TestResultSection, Modal };

--- a/src/page/Splash.tsx
+++ b/src/page/Splash.tsx
@@ -57,7 +57,7 @@ const StyledButton = styled.button`
   padding: 0 48px 0 18px;
   border: none;
   background-color: #fee500;
-  color: 000000;
+  color: #000000;
   font-size: 18px;
   line-height: 56px;
   border-radius: 6px;


### PR DESCRIPTION
## Changes Made

- index.ts에서 Header와 SplashCarousel import 다시 해오기
- Header의 height를 padding으로 대체, max-width를 width로 대체
- 헤더 컴포넌트에서 로그인 상태 여부에 따라 로그아웃/마이페이지로 전환.

## Reference

Issue #12
