### PR TITLE
버튼 공통 컴포넌트 생성

### DIFF
--- a/src/components/common/GalmuriButton.tsx
+++ b/src/components/common/GalmuriButton.tsx
@@ -21,6 +21,7 @@ const Button = styled.button<ButtonProps>`
   border-radius: 20px;
   font-weight: 600;
   transition: all 0.3s;
+  text-align: center;
   &:hover {
     background-color: var(--dark-color); // 임시
   }

--- a/src/components/common/GalmuriButton.tsx
+++ b/src/components/common/GalmuriButton.tsx
@@ -1,14 +1,24 @@
 import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
 
 interface ButtonProps {
   text?: string;
   backgroundColor?: string;
   color?: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  to?: string;
 }
 
 export const GalmuriButton = ({ text, ...props }: ButtonProps) => {
   return <Button {...props}>{text}</Button>;
+};
+
+export const GalmuriLink = ({ text, to, ...props }: ButtonProps) => {
+  return (
+    <Button as={Link} to={to} {...props}>
+      {text}
+    </Button>
+  );
 };
 
 const Button = styled.button<ButtonProps>`

--- a/src/components/common/GalmuriButton.tsx
+++ b/src/components/common/GalmuriButton.tsx
@@ -4,6 +4,7 @@ interface ButtonProps {
   text?: string;
   backgroundColor?: string;
   color?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const GalmuriButton = ({ text, ...props }: ButtonProps) => {

--- a/src/components/common/GalmuriButton.tsx
+++ b/src/components/common/GalmuriButton.tsx
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+
+interface ButtonProps {
+  text?: string;
+  backgroundColor?: string;
+  color?: string;
+}
+
+export const GalmuriButton = ({ text, ...props }: ButtonProps) => {
+  return <Button {...props}>{text}</Button>;
+};
+
+const Button = styled.button<ButtonProps>`
+  cursor: pointer;
+  font-family: var(--font--Galmuri);
+  font-size: 1.25rem;
+  padding: 20px 60px;
+  background-color: var(--main-color);
+  color: #fff;
+  border-radius: 20px;
+  font-weight: 600;
+  transition: all 0.3s;
+  &:hover {
+    background-color: var(--dark-color); // 임시
+  }
+`;

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -22,6 +22,7 @@ const Button = styled.button<ButtonProps>`
   border: ${props => (props.dark ? "1px solid #222222" : "1px solid #DBDBDB")};
   border-radius: 20px;
   transition: all 0.3s;
+  text-align: center;
   &:hover {
     // 임시
     background-color: ${props => (props.dark ? "#122134" : "#DBDBDB")};

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -2,12 +2,28 @@ import styled from "@emotion/styled";
 
 interface ButtonProps {
   text?: string;
-  backgroundColor?: string;
-  color?: string;
+  dark?: boolean;
+  width?: string;
 }
 
 export const RoundButton = ({ text, ...props }: ButtonProps) => {
   return <Button {...props}>{text}</Button>;
 };
 
-const Button = styled.button<ButtonProps>``;
+const Button = styled.button<ButtonProps>`
+  cursor: pointer;
+  width: ${props => props.width || "auto"};
+  font-family: var(--font--Pretendard);
+  font-size: 1rem;
+  padding: 16px;
+  background-color: ${props => (props.dark ? "#192E47" : "#f4f4f4")};
+  color: ${props => (props.dark ? "#fff" : "#222")};
+  border: ${props => (props.dark ? "1px solid #222222" : "1px solid #DBDBDB")};
+  border-radius: 20px;
+  transition: all 0.3s;
+  &:hover {
+    // 임시
+    background-color: ${props => (props.dark ? "#122134" : "#DBDBDB")};
+    border: ${props => (props.dark ? "1px solid #222222" : "1px solid #989898")};
+  }
+`;

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -1,14 +1,24 @@
 import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
 
 interface ButtonProps {
   text?: string;
   dark?: boolean;
   width?: string;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  to?: string;
 }
 
 export const RoundButton = ({ text, ...props }: ButtonProps) => {
   return <Button {...props}>{text}</Button>;
+};
+
+export const RoundLink = ({ text, to, ...props }: ButtonProps) => {
+  return (
+    <Button as={Link} to={to} {...props}>
+      {text}
+    </Button>
+  );
 };
 
 const Button = styled.button<ButtonProps>`

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -4,6 +4,7 @@ interface ButtonProps {
   text?: string;
   dark?: boolean;
   width?: string;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const RoundButton = ({ text, ...props }: ButtonProps) => {

--- a/src/components/common/RoundButton.tsx
+++ b/src/components/common/RoundButton.tsx
@@ -1,0 +1,13 @@
+import styled from "@emotion/styled";
+
+interface ButtonProps {
+  text?: string;
+  backgroundColor?: string;
+  color?: string;
+}
+
+export const RoundButton = ({ text, ...props }: ButtonProps) => {
+  return <Button {...props}>{text}</Button>;
+};
+
+const Button = styled.button<ButtonProps>``;

--- a/src/components/common/SquareButton.tsx
+++ b/src/components/common/SquareButton.tsx
@@ -3,6 +3,7 @@ import styled from "@emotion/styled";
 interface ButtonProps {
   text?: string;
   white?: boolean;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 export const SquareButton = ({ text, ...props }: ButtonProps) => {

--- a/src/components/common/SquareButton.tsx
+++ b/src/components/common/SquareButton.tsx
@@ -19,6 +19,7 @@ const Button = styled.button<ButtonProps>`
   color: ${props => (props.white ? "#222" : "#fff")};
   border-radius: 4px;
   font-weight: 600;
+  text-align: center;
   transition: all 0.3s;
   &:hover {
     background-color: ${props => (props.white ? "var(--gray300-color)" : "var(--dark-color)")}; // 임시

--- a/src/components/common/SquareButton.tsx
+++ b/src/components/common/SquareButton.tsx
@@ -1,0 +1,25 @@
+import styled from "@emotion/styled";
+
+interface ButtonProps {
+  text?: string;
+  white?: boolean;
+}
+
+export const SquareButton = ({ text, ...props }: ButtonProps) => {
+  return <Button {...props}>{text}</Button>;
+};
+
+const Button = styled.button<ButtonProps>`
+  cursor: pointer;
+  font-family: var(--font--Pretendard);
+  font-size: 1rem;
+  padding: 12px 24px;
+  background-color: ${props => (props.white ? "#fff" : "var(--main-color)")};
+  color: ${props => (props.white ? "#222" : "#fff")};
+  border-radius: 4px;
+  font-weight: 600;
+  transition: all 0.3s;
+  &:hover {
+    background-color: ${props => (props.white ? "var(--gray300-color)" : "var(--dark-color)")}; // 임시
+  }
+`;

--- a/src/components/common/SquareButton.tsx
+++ b/src/components/common/SquareButton.tsx
@@ -1,13 +1,23 @@
 import styled from "@emotion/styled";
+import { Link } from "react-router-dom";
 
 interface ButtonProps {
   text?: string;
   white?: boolean;
-  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>) => void;
+  to?: string;
 }
 
 export const SquareButton = ({ text, ...props }: ButtonProps) => {
   return <Button {...props}>{text}</Button>;
+};
+
+export const SquareLink = ({ text, to, ...props }: ButtonProps) => {
+  return (
+    <Button as={Link} to={to} {...props}>
+      {text}
+    </Button>
+  );
 };
 
 const Button = styled.button<ButtonProps>`

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,3 +7,6 @@ export * from "./codeCompare/ReadOnlyEditor.tsx";
 export * from "./common/Header";
 export * from "./carousel/SplashCarousel.tsx";
 export * from "./card/UserCard.tsx";
+export * from "./common/GalmuriButton.tsx";
+export * from "./common/SquareButton.tsx";
+export * from "./common/RoundButton.tsx";

--- a/src/page/CodeCompare.tsx
+++ b/src/page/CodeCompare.tsx
@@ -4,8 +4,8 @@ import gutter_vertical from "../assets/gutter_vertical.svg";
 import icon_bookmark from "../assets/icon_bookmark.svg";
 import icon_bookmark_true from "../assets/icon_bookmark_true.svg";
 import { useDraggable } from "../hook";
-import { Header, ReadOnlyEditor } from "../components";
-import { Link, useLocation } from "react-router-dom";
+import { Header, ReadOnlyEditor, SquareLink } from "../components";
+import { useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
 
 export const CodeCompare = () => {
@@ -67,7 +67,7 @@ export const CodeCompare = () => {
         </section>
       </Contain>
       <ButtonContain>
-        <Link to="/">나가기</Link>
+        <SquareLink to="/" text="나가기" />
       </ButtonContain>
     </>
   );
@@ -182,17 +182,6 @@ const ButtonContain = styled.div`
   padding: 10px 22px;
   display: flex;
   justify-content: flex-end;
-  & > a {
-    padding: 10px 24px;
-    font-size: 1rem;
-    background-color: var(--main-color);
-    color: #fff;
-    font-weight: 600;
-    border-radius: 4px;
-    &:disabled {
-      background-color: #757575;
-    }
-  }
   @media only screen and (max-width: 768px) {
     position: relative;
   }

--- a/src/page/CodingTest.tsx
+++ b/src/page/CodingTest.tsx
@@ -1,10 +1,20 @@
-import { CodeEditor, Header, Modal, SelectLang, TestDescSection, TestResultSection } from "../components";
+import {
+  CodeEditor,
+  Header,
+  Modal,
+  RoundButton,
+  RoundLink,
+  SelectLang,
+  SquareButton,
+  TestDescSection,
+  TestResultSection,
+} from "../components";
 import styled from "@emotion/styled";
 import gutter_horizontal from "../assets/gutter_horizontal.svg";
 import gutter_vertical from "../assets/gutter_vertical.svg";
 import { useDraggable } from "../hook";
 import { useEffect, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { getQuestionAPI } from "../api";
 import { Question_I } from "../interface";
 import icon_test_complete from "../assets/icon_test_complete.svg";
@@ -92,8 +102,8 @@ export const CodingTest = () => {
         </CodeContain>
       </Contain>
       <ButtonContain>
-        <button>코드 실행</button>
-        <button onClick={handleSubmit}>제출 후 채점하기</button>
+        <SquareButton text="코드 실행" white />
+        <SquareButton text="제출 후 채점하기" onClick={handleSubmit} />
       </ButtonContain>
       {isModal && (
         <Modal onClose={handleClose} modalHeader={testComplete ? "Test Complete" : "Test Failed"}>
@@ -105,9 +115,10 @@ export const CodingTest = () => {
             <strong>{testComplete ? "10 EXP 획득!" : "EXP 획득 실패"}</strong>
             <p>{testComplete ? "축하합니다! 문제를 맞추셨어요" : "다음 테스트엔 더 잘 할 수 있어요"}</p>
             <div>
-              <Link to="/">홈으로</Link>
+              <RoundLink to="/" text="홈으로" width="50%" />
               {testComplete ? (
-                <button
+                <RoundButton
+                  text="AI 설명 보기"
                   onClick={() =>
                     navigate("/CodeCompare", {
                       state: {
@@ -116,11 +127,11 @@ export const CodingTest = () => {
                       },
                     })
                   }
-                >
-                  AI 설명 보기
-                </button>
+                  dark
+                  width="50%"
+                />
               ) : (
-                <button onClick={() => setIsModal(false)}>다시 풀기</button>
+                <RoundButton text="다시 풀기" onClick={() => setIsModal(false)} dark width="50%" />
               )}
             </div>
           </ModalContain>
@@ -167,22 +178,6 @@ const ButtonContain = styled.div`
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
-  & > button {
-    cursor: pointer;
-    padding: 12px 24px;
-    font-size: 1rem;
-    background-color: #fff;
-    color: #000;
-    font-weight: 600;
-    border-radius: 4px;
-    &:disabled {
-      background-color: #757575;
-    }
-  }
-  & > button:last-of-type {
-    background-color: var(--main-color);
-    color: #fff;
-  }
   @media only screen and (max-width: 768px) {
     position: relative;
   }
@@ -224,22 +219,5 @@ const ModalContain = styled.div`
     margin-top: 24px;
     display: flex;
     gap: 20px;
-    & > a,
-    & > button {
-      width: 50%;
-      border-radius: 20px;
-      background-color: #f4f4f4;
-      border: 1px solid #dbdbdb;
-      color: #000;
-      padding: 16px;
-      font-size: 0.875rem;
-      text-align: center;
-    }
-    & > button {
-      cursor: pointer;
-      background-color: #222;
-      border: none;
-      color: #fff;
-    }
   }
 `;


### PR DESCRIPTION
## Changes Made

- 공통 컴포넌트 버튼 종류별로 만들어뒀습니다 (03/07)

## Review Point

- SquareButton 에는 white 옵션이 있고, RoundButton 에는 dark 옵션 있습니다
```js
<SquareButton text="제출 후 채점 하기" />
<SquareButton text="코드 실행" white />  // 이렇게 사용 가능
<RoundButton text="AI 설명 보기" dark />
<RoundButton text="홈으로" />
```

- GalmuriButton 은 혹시 몰라서 `backgroundColor`랑 `color` props 추가해뒀는데 사용하려면 emotion css 변경 필요합니당
- GalmuriLink 와 같이 Link가 붙어 있는 건 react-router-dom의 Link 역할을 함으로 `<SquareLink to="/" text="나가기" />` 와 같이 사용할 수 있습니다 

## Screenshot

![image](https://github.com/oxxun21/Code-Catcher-FE/assets/98699927/9df52aa7-c41b-46ff-bc74-8eedba6d86e0)

1. GalmuriButton
2. SquareButton
3. RoundButton 

## Question

- ❌

## Reference

Issue #35 
