### PR TITLE
페이지네이션 totalPage 다 나오도록 수정

### DIFF
--- a/src/components/list/Pagination.tsx
+++ b/src/components/list/Pagination.tsx
@@ -8,35 +8,31 @@ interface PaginationProps {
 }
 
 export const Pagination = ({ totalPage, currentPage, onPageChange }: PaginationProps) => {
-  const [pageGroup, setPageGroup] = useState(Math.floor(currentPage / 5));
-  const maxPageGroup = Math.ceil(totalPage / 5) - 1;
+  const pageGroupSize = 5;
+  const [pageGroup, setPageGroup] = useState(Math.floor(currentPage / pageGroupSize));
+  const maxPageGroup = Math.ceil((totalPage + 1) / pageGroupSize) - 1;
 
-  const handleNextGroup = () => {
-    if (pageGroup < maxPageGroup) {
-      setPageGroup(pageGroup + 1);
-      onPageChange(pageGroup * 5 + 5); // 다음 그룹의 첫 페이지로 이동
-    }
-  };
-
-  const handlePrevGroup = () => {
-    if (pageGroup > 0) {
-      const newPageGroup = pageGroup - 1;
-      setPageGroup(newPageGroup);
-      onPageChange(newPageGroup * 5); // 이전 그룹의 첫 페이지로 이동
-    }
+  const handlePageGroupChange = (direction: "next" | "prev") => {
+    setPageGroup(currentGroup => {
+      const newPageGroup = direction === "next" ? currentGroup + 1 : currentGroup - 1;
+      onPageChange(
+        direction === "next" ? currentGroup * pageGroupSize + pageGroupSize - 1 : newPageGroup * pageGroupSize
+      );
+      return newPageGroup;
+    });
   };
   // 현재 페이지 그룹에 따라 표시할 페이지 번호들을 계산
-  const startPage = pageGroup * 5 + 1;
-  const endPage = Math.max(Math.min(startPage + 4, totalPage), 1);
+  const startPage = pageGroup * pageGroupSize + 1;
+  const endPage = Math.min(startPage + pageGroupSize - 1, totalPage + 1);
   const pageNumbers = Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
 
-  const showBackButton = totalPage > 5;
-  const showNextButton = totalPage > 5;
+  const showBackButton = totalPage >= 5;
+  const showNextButton = totalPage >= 5;
 
   return (
     <StyledNav>
       {showBackButton && (
-        <button onClick={handlePrevGroup} disabled={pageGroup === 0}>
+        <button onClick={() => handlePageGroupChange("prev")} disabled={pageGroup === 0}>
           BACK
         </button>
       )}
@@ -50,7 +46,7 @@ export const Pagination = ({ totalPage, currentPage, onPageChange }: PaginationP
         ))}
       </ul>
       {showNextButton && (
-        <button onClick={handleNextGroup} disabled={pageGroup === maxPageGroup}>
+        <button onClick={() => handlePageGroupChange("next")} disabled={pageGroup === maxPageGroup}>
           NEXT
         </button>
       )}


### PR DESCRIPTION
## Changes Made

- 지난 테스트 내역과 북마크 페이지에 사용되는 페이지네이션 컴포넌트에서 
totalPage 값을 잘못 계산하여 마지막 장이 나오지 않는 문제가 여전히 있었습니당. 
다 나오도록 수정했어욥. 

## Screenshot

> 
![스크린샷 2024-04-04 153430_1](https://github.com/oxxun21/Code-Catcher-FE/assets/87015026/67ec6f0d-7da5-4a5f-9959-bbcdea922290)

![스크린샷 2024-04-04 153430_2](https://github.com/oxxun21/Code-Catcher-FE/assets/87015026/5711ec96-1e75-4d70-8103-6022a5f85550)


## Reference

Issue #82
