### PR TITLE
구글 번역 위젯 언어 전환 시 removeCookie로 쿠키 중복 방지

### DIFF
--- a/src/components/common/GoogleTranslate.tsx
+++ b/src/components/common/GoogleTranslate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import FlagEn from "../../assets/flag_en.svg";
 import FlagKo from "../../assets/flag_ko.svg";
@@ -15,7 +15,8 @@ export const GoogleTranslate = () => {
   const translateElementRef = useRef<HTMLDivElement>(null);
   const { width } = useWindowSize();
   const isMobile = (width ?? 0) <= 480;
-  const [cookies, setCookie] = useCookies(["googtrans"]);
+  const [cookies, setCookie, removeCookie] = useCookies(["googtrans"]);
+  const [isGoogTransKo, setIsGoogTransKo] = useState<boolean>(true);
 
   useEffect(() => {
     window.googleTranslateElementInit = () => {
@@ -35,18 +36,21 @@ export const GoogleTranslate = () => {
     }
   }, []);
 
+  useEffect(() => {
+    const currentLang = cookies.googtrans;
+    setIsGoogTransKo(!currentLang || currentLang === "/ko");
+  }, [cookies.googtrans]);
+
   // 언어 변경 처리
   const handleLanguageChange = (lang: String) => {
-    const currentLang = cookies.googtrans;
-    const newLang = `/${lang}`;
-
-    if (currentLang !== newLang) {
-      setCookie("googtrans", newLang, { path: "/" });
-      window.location.reload();
+    if (cookies.googtrans && cookies.googtrans !== `/${lang}`) {
+      removeCookie("googtrans", { path: "/" });
     }
-  };
 
-  const isGoogTransKo = cookies.googtrans === "/ko";
+    // 쿠키를 새로 설정
+    setCookie("googtrans", `/${lang}`, { path: "/" });
+    window.location.reload();
+  };
 
   return (
     <div>

--- a/src/page/QuestionSelect.tsx
+++ b/src/page/QuestionSelect.tsx
@@ -16,6 +16,7 @@ export const QuestionSelect = () => {
 
   const [selectedQuestionId, setSelectedQuestionId] = useState<number | null>(null);
   const navigate = useNavigate();
+  const trackEvent = useEventTracker();
 
   useEffect(() => {
     const fetchQuestions = async () => {
@@ -71,6 +72,12 @@ export const QuestionSelect = () => {
                 onClick={() => {
                   setSelectedCard(selectedCard === index ? null : index);
                   setSelectedQuestionId(selectedCard === index ? null : question.id);
+
+                  trackEvent({
+                    category: "CodingTest",
+                    action: "selectQuestionCard",
+                    label: `문제Id:${question.id}`,
+                  });
                 }}
                 onMouseEnter={() => setHoveredCard(index)}
                 onMouseLeave={() => setHoveredCard(null)}


### PR DESCRIPTION
## Changes Made

- 언어 전환할 때마다 removeCookie하고 새로 쿠키 set하도록 수정해봤습니다. 
배포 후 확인해보고 이 방법도 안되면 잠시 배포단에서는 번역 위젯 제거해둬야할 것 같아요. 

## Reference

Issue #106 
