### PR TITLE
구글번역 위젯 js로 goog-te-combo 직접 조작하는 방식으로 변경

### DIFF
--- a/src/components/card/QuestionCard.tsx
+++ b/src/components/card/QuestionCard.tsx
@@ -155,6 +155,11 @@ const StyledDesc = styled.div<{ isSuccess: boolean | null }>`
     color: var(--black-color);
     margin: 0.75rem 0;
     line-height: 122%;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   & h3 {
     font-size: 1.25rem;

--- a/src/components/common/GoogleTranslate.tsx
+++ b/src/components/common/GoogleTranslate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, memo } from "react";
+import { useLocation } from "react-router-dom";
 import { useCookies } from "react-cookie";
 import FlagEn from "../../assets/flag_en.svg";
 import FlagKo from "../../assets/flag_ko.svg";
@@ -15,43 +16,58 @@ export const GoogleTranslate = memo(() => {
   const translateElementRef = useRef<HTMLDivElement>(null);
   const { width } = useWindowSize();
   const isMobile = (width ?? 0) <= 480;
-  const [cookies, setCookie, removeCookie] = useCookies(["googtrans"]);
+  const [cookies] = useCookies(["googtrans"]);
+  const [translateWidgetLoaded, setTranslateWidgetLoaded] = useState(false);
   const [isGoogTransKo, setIsGoogTransKo] = useState<boolean>(true);
+  const location = useLocation();
 
   useEffect(() => {
+    const scriptId = "google-translate-script";
+    const script = document.createElement("script");
+    script.id = scriptId;
+    script.src = "//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit";
+    document.body.appendChild(script);
+
     window.googleTranslateElementInit = () => {
-      new (window.google as any).translate.TranslateElement(
-        { pageLanguage: "ko", autoDisplay: true },
-        translateElementRef.current?.id
-      );
+      if (translateElementRef.current) {
+        new window.google.translate.TranslateElement(
+          { pageLanguage: "ko", autoDisplay: true },
+          translateElementRef.current?.id
+        );
+      }
+      setTranslateWidgetLoaded(true);
     };
-    if (!window.google || !window.google.translate) {
-      const script = document.createElement("script");
-      script.src = "//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit";
-      document.body.appendChild(script);
 
-      return () => {
-        document.body.removeChild(script);
-      };
-    }
-  }, []);
+    script.onload = () => setTranslateWidgetLoaded(true);
+    script.onerror = () => setTranslateWidgetLoaded(false);
+
+    return () => {
+      document.body.removeChild(script);
+      delete window.googleTranslateElementInit;
+    };
+  }, [location]);
 
   useEffect(() => {
-    const currentLang = cookies.googtrans;
-    setIsGoogTransKo(!currentLang || currentLang === "/ko");
-  }, [cookies.googtrans]);
-
-  // 언어 변경 처리
-  const handleLanguageChange = (lang: String) => {
-    if (cookies.googtrans && cookies.googtrans !== `/${lang}`) {
-      removeCookie("googtrans", { path: "/", domain: window.location.hostname });
+    if (translateWidgetLoaded) {
+      const currentLang = cookies.googtrans === "/ko/en" ? "en" : "ko";
+      refreshTranslateElement(currentLang);
     }
-    console.log("Google Translate Rendering");
+  }, [translateWidgetLoaded, cookies.googtrans]);
 
-    // 쿠키를 새로 설정
-    setCookie("googtrans", `/${lang}`, { path: "/", domain: window.location.hostname });
+  const refreshTranslateElement = (langCode: string) => {
+    console.log("[langCode]", langCode);
+    const gtcombo = document.querySelector(".goog-te-combo") as HTMLSelectElement;
+    if (!gtcombo) {
+      console.log("Waiting for gtcombo to be available...");
+      setTimeout(() => refreshTranslateElement(langCode), 500);
+      return;
+    }
 
-    window.location.reload();
+    gtcombo.value = langCode; // 변경할 언어 적용
+    gtcombo.dispatchEvent(new Event("change")); // 변경 이벤트 트리거
+    setIsGoogTransKo(langCode === "ko");
+
+    console.log("[gtCombo]", gtcombo.value);
   };
 
   return (
@@ -60,14 +76,14 @@ export const GoogleTranslate = memo(() => {
       <ul className="translation-links">
         {isGoogTransKo ? (
           <li>
-            <a onClick={() => handleLanguageChange("en")}>
+            <a onClick={() => refreshTranslateElement("en")}>
               <img src={FlagEn} alt="English" />
               {isMobile && <p>ENG</p>}
             </a>
           </li>
         ) : (
           <li>
-            <a onClick={() => handleLanguageChange("ko")}>
+            <a onClick={() => refreshTranslateElement("ko")}>
               <img src={FlagKo} alt="Korean" />
               {isMobile && <p>KOR</p>}
             </a>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -13,6 +13,7 @@ import { withdrawAPI } from "../../api";
 import { useEventTracker, useWindowSize } from "../../hook";
 import { useCookies } from "react-cookie";
 import useAutoLogout from "../../hook/useAutoLogout.tsx";
+import { GoogleTranslate } from "./GoogleTranslate.tsx";
 
 type ModalContentType = "logout" | "withdraw" | "leavePage" | "";
 
@@ -196,7 +197,7 @@ export const Header = memo(() => {
           <img src={logoImage} alt="로고 이미지" onClick={handleNavigateToHome} />
         </h1>
         <StyledLeftNav>
-          {/* {isMobile ? null : <GoogleTranslate />} */}
+          {isMobile ? null : <GoogleTranslate />}
           {!isLoggedIn ? (
             <StyledLoginBtn onClick={handleKakaoLogin}>{isGoogTransEn ? "Login" : "로그인"}</StyledLoginBtn>
           ) : (

--- a/src/page/Home.tsx
+++ b/src/page/Home.tsx
@@ -2,14 +2,16 @@ import { useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getLoginCookie } from "../utils/loginCookie.ts";
 import styled from "@emotion/styled";
-import { Header, GalmuriButton, HelmetMetaTags } from "../components";
+import { Header, GalmuriButton, HelmetMetaTags, GoogleTranslate } from "../components";
 import { UserCard } from "../components";
 import { metaData } from "../meta/metaData.ts";
 import { useCookies } from "react-cookie";
+import { useWindowSize } from "../hook/index.ts";
 
 export const Home = () => {
   const navigate = useNavigate();
-
+  const { width } = useWindowSize();
+  const isMobile = (width ?? 0) <= 480;
   const [cookies] = useCookies(["googtrans"]);
   const isGoogTransEn = cookies.googtrans === "/ko/en";
 
@@ -32,7 +34,7 @@ export const Home = () => {
           to="question/select"
           text={isGoogTransEn ? "Start Today's Test" : "오늘의 코테 시작하기"}
         />
-        {/* {isMobile && <GoogleTranslate />} */}
+        {isMobile && <GoogleTranslate />}
       </StyledMain>
     </>
   );


### PR DESCRIPTION
## Changes Made

- 쿠키 조작 대신 js로 goog-te-combo 직접 조작하는 방식으로 변경
- 페이지 새로고침하지 않고 변경되도록 goog-te-combo 요소 찾지 못할 시 다시 script 갖고오도록 변경

## Reference

Issue #106 
