### PR TITLE
코드 에디터 탭 사이즈 고정

### DIFF
--- a/src/api/instance.ts
+++ b/src/api/instance.ts
@@ -7,6 +7,7 @@ export const instance = axios.create({
   headers: {
     Authorization: `Bearer ${getLoginCookie()}`,
     "Content-Type": "application/json",
+    "X-Forwarded-Host": "https://likelion-codee.com",
   },
 });
 

--- a/src/components/codeCompare/ReadOnlyEditor.tsx
+++ b/src/components/codeCompare/ReadOnlyEditor.tsx
@@ -77,6 +77,8 @@ export const ReadOnlyEditor = ({ code, language }: ReadOnlyEditorProps) => {
         language={language}
         options={{
           tabSize: 4,
+          insertSpaces: true,
+          detectIndentation: false,
           readOnly: true,
           fontSize: 14,
           minimap: { enabled: false },

--- a/src/components/codingTest/CodeEditor.tsx
+++ b/src/components/codingTest/CodeEditor.tsx
@@ -51,11 +51,13 @@ export const CodeEditor = ({ editorHeight, language, setCodeValue, question, isM
       case "Java":
         return question?.javaSubmitCode
           ? question.javaSubmitCode
-          : `public class Main {
+          : `import java.util.Scanner;
+          
+public class Main {
     public static void main(String[] args) {
       // 자바 코드를 입력하세요.
     }
-  }`;
+}`;
       case "Python":
         return question?.pythonSubmitCode ? question.pythonSubmitCode : "# 파이썬 코드를 입력해주세요";
       case "javascript":
@@ -76,6 +78,8 @@ export const CodeEditor = ({ editorHeight, language, setCodeValue, question, isM
         value={defaultContent}
         options={{
           tabSize: 4,
+          insertSpaces: true,
+          detectIndentation: false,
           fontSize: 14,
           minimap: { enabled: false },
           scrollbar: {


### PR DESCRIPTION
## Changes Made

- 코드 에디터 탭 사이즈 4로 고정 되었습니다
- 자바 기본 코드에 import 문 추가 했습니다

## Review Point

- 리뷰어가 확인해야 할 사항 코멘트

## Screenshot

<img width="884" alt="image" src="https://github.com/oxxun21/Code-Catcher-FE/assets/98699927/5ae603ba-cbb4-485c-b254-9c36da931ae1">


## Question

> 의논할 사항

## Reference

Issue #111
